### PR TITLE
追加osx下编译

### DIFF
--- a/examples/hello-class/.cargo/config.toml
+++ b/examples/hello-class/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-Clink-args=-Wl,-undefined,dynamic_lookup"]

--- a/examples/hello/.cargo/config.toml
+++ b/examples/hello/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-Clink-args=-Wl,-undefined,dynamic_lookup"]

--- a/examples/mini-curl/.cargo/config.toml
+++ b/examples/mini-curl/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-Clink-args=-Wl,-undefined,dynamic_lookup"]

--- a/phper-alloc/src/lib.rs
+++ b/phper-alloc/src/lib.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 pub type EBox<T> = Box<T, Allocator>;
-pub type EVec<T> = Vec<T, Allocator>;
+pub type EVec<T> = Vec<(T, Allocator)>;
 
 pub struct Allocator {
     #[cfg(phper_debug)]

--- a/phper/src/zend/types.rs
+++ b/phper/src/zend/types.rs
@@ -3,11 +3,12 @@ use crate::{
     sys::{
         self, phper_get_this, phper_init_class_entry_ex, phper_z_strval_p, phper_zval_get_type,
         phper_zval_stringl, zend_class_entry, zend_declare_property_bool,
-        zend_declare_property_long, zend_declare_property_null, zend_declare_property_stringl,
-        zend_execute_data, zend_long, zend_parse_parameters, zend_read_property,
-        zend_register_internal_class, zend_throw_exception, zend_update_property_bool,
-        zend_update_property_long, zend_update_property_null, zend_update_property_stringl, zval,
-        IS_DOUBLE, IS_FALSE, IS_LONG, IS_NULL, IS_TRUE, ZEND_RESULT_CODE_SUCCESS,
+        zend_declare_property_double, zend_declare_property_long, zend_declare_property_null,
+        zend_declare_property_stringl, zend_execute_data, zend_long, zend_parse_parameters,
+        zend_read_property, zend_register_internal_class, zend_throw_exception,
+        zend_update_property_bool, zend_update_property_double, zend_update_property_long,
+        zend_update_property_null, zend_update_property_stringl, zval, IS_DOUBLE, IS_FALSE,
+        IS_LONG, IS_NULL, IS_TRUE, ZEND_RESULT_CODE_SUCCESS,
     },
     zend::{api::FunctionEntries, compile::Visibility, exceptions::Throwable},
 };
@@ -171,6 +172,21 @@ impl HandleProperty for i64 {
             name.len(),
             self as zend_long,
         )
+    }
+}
+
+impl HandleProperty for f64 {
+    unsafe fn declare_property(
+        self,
+        ce: *mut zend_class_entry,
+        name: &str,
+        access_type: i32,
+    ) -> i32 {
+        zend_declare_property_double(ce, name.as_ptr().cast(), name.len(), self, access_type)
+    }
+
+    unsafe fn update_property(self, scope: *mut zend_class_entry, object: *mut zval, name: &str) {
+        zend_update_property_double(scope, object, name.as_ptr().cast(), name.len(), self)
     }
 }
 


### PR DESCRIPTION
1. 我在osx平台下编译出错，对examples追加了编译配置
2.追加了 HandleProperty  for f64


另外  phper-alloc/src/lib.rs 的 Vec<T, Allocator> 编译不通过修改为了  Vec<(T, Allocator)>。

如果可以的，能给讲下开发思路么