### PR TITLE
 追加 target_os 支持

### DIFF
--- a/phper-test/src/lib.rs
+++ b/phper-test/src/lib.rs
@@ -171,7 +171,12 @@ fn get_lib_path(exe_path: impl AsRef<Path>) -> PathBuf {
     let mut ext_name = OsString::new();
     ext_name.push("lib");
     ext_name.push(exe_stem.replace('-', "_"));
+    #[cfg(target_os = "linux")]
     ext_name.push(".so");
+    #[cfg(target_os = "macos")]
+    ext_name.push(".dylib");
+    #[cfg(target_os = "windows")]
+    ext_name.push(".dll");
 
     target_dir.join(ext_name)
 }


### PR DESCRIPTION
test 时候 so 后缀仅在linux下有效, 追加 windows 的dll和 macos 的dylib 支持